### PR TITLE
Remove PatchAll to fix double patching

### DIFF
--- a/MainMod.cs
+++ b/MainMod.cs
@@ -19,8 +19,6 @@ namespace microblock
         private const string UIMOD_EXTRACT_DIR= "ChilloutVR_Data/StreamingAssets/Cohtml/UIResources/UIMods";
         private const string UIMOD_USER_DIR = "UIMods";
 
-        public static HarmonyLib.Harmony MyHarmony = new HarmonyLib.Harmony("cc.microblock.CVRUIModLoader");
-
         public override void OnApplicationStart()
         {
             LoggerInstance.Msg("Hooking To ViewManager.UiStateToggle ...");
@@ -65,7 +63,6 @@ namespace microblock
 
 File.WriteAllText($"{UIMOD_EXTRACT_DIR}/mods.json", JsonConvert.SerializeObject(loadedMods));
 
-            MyHarmony.PatchAll();
             LoggerInstance.Msg("Patches Applied!");
         }
 


### PR DESCRIPTION
https://melonwiki.xyz/#/modders/patching?id=using-attributes second last paragraph explains that it's called by Melon Loader for Harmony Attributes by default.